### PR TITLE
Add working cname

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+sentry (0.5-1) unstable; urgency=low
+
+  * Add 'cname' rule type for returning a CNAME record and corresponding A record
+
+
+ -- Team Kano <dev@kano.me>  Wed, 22 Oct 2014 09:57:49 +0001
+
 sentry (0.5-0) unstable; urgency=low
 
   * Initial release.

--- a/sentry/parser.py
+++ b/sentry/parser.py
@@ -6,6 +6,7 @@ log = logging.getLogger(__name__)
 
 RULES = [
 	rules.RedirectRule,
+	rules.CNameRule,
 	rules.BlockRule,
 	rules.ConditionalBlockRule,
 	rules.LoggingRule,

--- a/sentry/rules.py
+++ b/sentry/rules.py
@@ -189,6 +189,7 @@ class ResolveRule(Rule):
 class CNameRule(Rule):
     """
     redirects a query using a CNAME
+    Unlike 'redirect', also supply A/AAAA record for the dst
     """
     SYNTAX = [
         # redirect ^(.*)google.com to nytimes.com
@@ -201,17 +202,20 @@ class CNameRule(Rule):
             self.dst += '.'
 
         resolvers = args.get('resolvers', None)
-
-        self.resolvers =  map(lambda x: x.strip(), resolvers.split(','))
-        log.debug('resolvers: %s' % self.resolvers)
-
-        self.upstream = dns.resolver.Resolver(filename=None,configure = False)
-        self.upstream.nameservers = self.resolvers
-
+        
         # how long we wait on upstream dns servers before puking
         self.timeout = settings.get('resolution_timeout', DEFAULT_TIMEOUT)
-        self.upstream.timeout=self.timeout
         log.debug('timeout: %d' % self.timeout)
+
+        # Add way to obtain A record for dst
+        def get_resolver(nameserver):
+            res =  dns.resolver.Resolver(filename=None,configure = False)
+            res.nameservers = [nameserver]
+            res.timeout = self.timeout
+            return res
+
+        self.resolvers = map(lambda x: get_resolver(x.strip()), resolvers.split(','))
+        log.debug('resolvers: %s' % self.resolvers)
 
         self.pool = futures.ThreadPoolExecutor(max_workers=len(self.resolvers))
 
@@ -219,20 +223,26 @@ class CNameRule(Rule):
 
     @profile.howfast
     def dispatch(self, message, *args, **extras):
+        # return a CNAME plus A/AAAA records for destination of redirect
 
+        
         # used for querying dns servers in parallel:
         @profile.howfast
         def _resolver(message, resolver):
-            log.debug('sending %s to %s ' % (message,resolver))
-            return self.upstream.query(self.dst, "A")
+            log.debug('sending %s to %s ' % (message,resolver.nameservers))
+            return resolver.query(self.dst, "A")
 
+        # First get the A/AAA records:
         fs = [ self.pool.submit( _resolver, message, resolver) for resolver in self.resolvers ]
         result = futures.wait(fs,return_when=futures.FIRST_COMPLETED).done.pop()
 
         if not result.exception():
+            # First make the CNAME part of the response
             response = dns.message.make_response(message)
             resp_data = dns.rrset.from_text(message.question[0].name, DEFAULT_TTL, dns.rdataclass.IN, dns.rdatatype.CNAME, self.dst)
             response.answer.append(resp_data)
+
+            # Add A/AAAA records to it
             r= result.result()
             for a in r:
                 if a.rdclass == dns.rdataclass.IN and (a.rdtype == dns.rdatatype.A or a.rdtype == dns.rdatatype.AAAA):


### PR DESCRIPTION
Sentry doesn't implement cname redirect properly, which is necessary for https://github.com/KanoComputing/peldins/issues/2294. This PR adds a new rule type to do so.

 This needs more testing. Adding this PR just to avoid forgetting what this branch is for.

Sentry produces lots of backtraces on stderr - I think it always did, whenever you try to look up a domain name that doesn't exist, but it makes it less obvious that this is bug-free.
